### PR TITLE
Fixed bug where changing image size in config wouldnt change anything…

### DIFF
--- a/led/pipelines/led_pipeline.py
+++ b/led/pipelines/led_pipeline.py
@@ -33,6 +33,7 @@ class LEDPipeline(DiffusionPipeline):
     def __init__(self, unet=None, scheduler=None, base_pipeline='ddim', backend=None, num_cond_steps=800, image_size=512):
         super().__init__()
         # make sure scheduler can always be converted to DDIM (basically)
+        self.unet = unet
         if scheduler is None:
             scheduler = self._set_default_scheduler()
         if unet is None:

--- a/led/trainers/led_trainer.py
+++ b/led/trainers/led_trainer.py
@@ -269,6 +269,7 @@ class Trainer():
                     pipeline = LEDPipeline(
                         unet=unwrap_model,
                         scheduler=self.noise_scheduler,
+                        image_size=self.config.data.image_size,
                     )
                     generator = torch.Generator(device=pipeline.device).manual_seed(0)
                     # run pipeline in inference (sample random noise and denoise)


### PR DESCRIPTION
…. Also Unet sometimes not loading

Tried to use in my project, but my images were 224x224. Even though config changed, the call to LEDPipeline did not include the updated image size, so default size of 512x512 was used instead, causing crash.
Also ensured self.unet was loaded with parameter for when it is called with one already built (needed to do to fix crash on windows 10 device)